### PR TITLE
Quote graph and subgraph names 

### DIFF
--- a/lib/graph.rb
+++ b/lib/graph.rb
@@ -339,8 +339,9 @@ class Graph
   def to_s
     result = []
 
-    type = graph ? "subgraph" : "digraph"
-    result << "#{type} #{name}"
+    type = graph ? "subgraph " : "digraph "
+    type << "\"#{name}\"" if name and !name.empty?
+    result << type
     result << "  {"
 
     graph_attribs.each do |line|

--- a/test/test_graph.rb
+++ b/test/test_graph.rb
@@ -227,7 +227,7 @@ class TestGraph < MiniTest::Unit::TestCase
 
     graph << g
 
-g_s = "subgraph subgraph
+g_s = "subgraph \"subgraph\"
   {
     \"a\";
     \"c\";


### PR DESCRIPTION
Tried to map a rakefile with namespaces and graphviz choked on the : in the fully qualified task names as subgraph/graph names.

Quoting the names (like it's done with the nodes) removes the problem
