### PR TITLE
Typo fix for vim

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,4 +30,4 @@ task :clean do
   rm_f Dir[*pngs] + Dir[*dots]
 end
 
-# vim: syntax=Ruby
+# vim: syntax=ruby


### PR DESCRIPTION
gvim/vim didn't pick up the syntax command as "Ruby" does not exist.
